### PR TITLE
feat(messages): list chat room messages

### DIFF
--- a/packages/api-gateway/__tests__/places/places.test.js
+++ b/packages/api-gateway/__tests__/places/places.test.js
@@ -13,9 +13,10 @@ describe('Given a client that wants to save a new place', () => {
     test('Then the server must send a 200 status code', async () => {
       const response = await fastify.inject({
         method: 'POST',
-        url: 'places',
+        url: '/places',
         body: newPlaceInfo,
       });
+
       expect(response.statusCode).toBe(201);
     });
   });
@@ -25,7 +26,7 @@ describe('Given a client that wants to save a new place', () => {
     test('Then the server must send a 400 status code', async () => {
       const response = await fastify.inject({
         method: 'POST',
-        url: 'places',
+        url: '/places',
         body: {
           place_name: newPlaceInfo.place_name,
         },

--- a/packages/api-gateway/__tests__/src/drivers/http/routes/chats/get-chat-messages.test.js
+++ b/packages/api-gateway/__tests__/src/drivers/http/routes/chats/get-chat-messages.test.js
@@ -1,0 +1,82 @@
+// External dependencies
+const { faker } = require('@faker-js/faker');
+
+// Internal dependencies
+const { fastify } = require('../../../../../../src/drivers/http/server');
+
+describe('GET /chats/{chatId}/messages', () => {
+  describe('given an authenticated user and a valid chatId', () => {
+    // TODO: Change this once we have authentication ready
+    const bearerToken = faker.datatype.uuid();
+    const chatId = 1;
+
+    const headers = {
+      Authorization: `Bearer ${bearerToken}`,
+    };
+
+    describe('when requesting page 1', () => {
+      let response;
+      let responseJson;
+
+      beforeAll(async () => {
+        response = await fastify.inject({
+          method: 'GET',
+          url: `/chats/${chatId}/messages`,
+          headers,
+        });
+
+        responseJson = response.json();
+      });
+
+      test('then status should be 200', () => {
+        expect(response.statusCode).toBe(200);
+      });
+
+      test('response should match pagination schema', () => {
+        expect(responseJson).toHaveProperty('page');
+        expect(typeof responseJson.page).toBe('number');
+        expect(responseJson).toHaveProperty('pages');
+        expect(typeof responseJson.pages).toBe('number');
+        expect(responseJson).toHaveProperty('rows');
+        expect(Array.isArray(responseJson.rows)).toBe(true);
+      });
+
+      test('response should have at least one element', () => {
+        expect(responseJson.rows.length).toBeGreaterThan(0);
+      });
+
+      test('and the element should match schema', () => {
+        const item = responseJson.rows[0];
+        expect(item._id).toBeDefined();
+        expect(item.chatId).toBeDefined();
+        expect(item.text).toBeDefined();
+        expect(item.createdAt).toBeDefined();
+        expect(item.createdBy).toBeDefined();
+      });
+    });
+
+    describe('when requesting with a non-integer value as page', () => {
+      /** @type {import('fastify').FastifyReply} */
+      let response;
+
+      beforeAll(async () => {
+        response = await fastify.inject({
+          method: 'GET',
+          url: `/chats/${chatId}/messages?page=foo`,
+          headers,
+        });
+      });
+
+      test('then status should be 400', () => {
+        expect(response.statusCode).toBe(400);
+      });
+
+      test('response should match error schema', () => {
+        const responseJson = response.json();
+        expect(responseJson).toHaveProperty('error');
+        expect(responseJson).toHaveProperty('message');
+        expect(responseJson).toHaveProperty('statusCode');
+      });
+    });
+  });
+});

--- a/packages/api-gateway/jest.config.js
+++ b/packages/api-gateway/jest.config.js
@@ -38,10 +38,9 @@ module.exports = {
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: [
-    'text-summary',
-  //   "json",
-  //   "text",
-  //   "lcov",
+    'text-summary', 'lcov',
+    //   "json",
+    //   "text",
   //   "clover"
   ],
 

--- a/packages/api-gateway/src/drivers/http/adapters/messages/handlers.js
+++ b/packages/api-gateway/src/drivers/http/adapters/messages/handlers.js
@@ -44,6 +44,28 @@ async function listUserChatRooms(req, reply) {
   return reply.code(200).send(paginatedResult);
 }
 
+/**
+ * List the mesages of a user chat room.
+ * @type {import('fastify').RouteHandler}
+ */
+async function listChatMessages(req, reply) {
+  const { chatId } = req.params;
+  const { page } = req.query;
+
+  // TODO: Add use case to validate if chat exists and belongs to the user.
+
+  req.log.info('[http-server]: Listing chat messages.');
+  const { pages, messages } = await this.messageServices.listChatMessages({
+    chatId,
+    page,
+  });
+
+  const paginatedResult = makePagination(page, pages, messages);
+
+  return reply.code(200).send(paginatedResult);
+}
+
 module.exports = {
   listUserChatRooms,
+  listChatMessages,
 };

--- a/packages/api-gateway/src/drivers/http/adapters/places/handlers.js
+++ b/packages/api-gateway/src/drivers/http/adapters/places/handlers.js
@@ -1,17 +1,23 @@
 async function postPlace(req, reply) {
   const {
-    place_name, price_per_night_usd, host_id, type,
+    place_name: placeName,
+    price_per_night_usd: pricePerNightUsd,
+    host_id: hostId,
+    type,
   } = req.body;
 
   req.log.info('[http-server]: posting a place');
 
   await this.placesService.postPlace({
-    place_name, price_per_night_usd, host_id, type,
+    place_name: placeName,
+    price_per_night_usd: pricePerNightUsd,
+    host_id: hostId,
+    type,
   });
 
   return reply.code(201)
     .header('Content-Type', 'application/json; chartset:utf-8')
-    .send({ msg: `${place_name} has been saved correctly.` });
+    .send({ msg: `${placeName} has been saved correctly.` });
 }
 
 module.exports = {

--- a/packages/api-gateway/src/drivers/http/routes/chats/index.js
+++ b/packages/api-gateway/src/drivers/http/routes/chats/index.js
@@ -1,6 +1,6 @@
 // Internal dependencies
 const { messageAdapters } = require('../../adapters');
-const { listChatRoomsSchema } = require('./schema');
+const { listChatRoomsSchema, listChatMessagesSchema } = require('./schema');
 
 /** @type {import('fastify').FastifyPluginCallback} */
 function chatRouter(fastify, _options, done) {
@@ -8,6 +8,11 @@ function chatRouter(fastify, _options, done) {
   fastify.get('/', {
     schema: listChatRoomsSchema,
     handler: messageAdapters.listUserChatRooms,
+  });
+
+  fastify.get('/:chatId/messages', {
+    schema: listChatMessagesSchema,
+    handler: messageAdapters.listChatMessages,
   });
 
   done();

--- a/packages/api-gateway/src/drivers/http/routes/chats/schema.js
+++ b/packages/api-gateway/src/drivers/http/routes/chats/schema.js
@@ -1,3 +1,30 @@
+const MESSAGE_PROPS = {
+  _id: { type: 'string' },
+  chatId: { type: 'string' },
+  text: { type: 'string' },
+  createdAt: { type: 'string' },
+  createdBy: { type: 'string' },
+};
+
+const PAGE_PARAM_PROPS = {
+  type: 'integer',
+  description: 'Page number',
+  minimum: 1,
+  default: 1,
+};
+
+const paginatedSchema = (props) => ({
+  type: 'object',
+  properties: {
+    page: { type: 'integer' },
+    pages: { type: 'integer' },
+    rows: {
+      type: 'array',
+      items: props,
+    },
+  },
+});
+
 /** @type {import('fastify').RouteOptions['schema']} */
 const listChatRoomsSchema = {
   description: 'List the chat rooms of the requesting user.',
@@ -6,51 +33,58 @@ const listChatRoomsSchema = {
   querystring: {
     type: 'object',
     properties: {
-      page: {
-        type: 'integer',
-        description: 'Page number',
-        minimum: 1,
-        default: 1,
-      },
+      page: PAGE_PARAM_PROPS,
     },
     required: ['page'],
   },
   response: {
-    200: {
+    200: paginatedSchema({
       type: 'object',
       properties: {
-        page: { type: 'integer' },
-        pages: { type: 'integer' },
-        rows: {
-          type: 'array',
-          items: {
-            type: 'object',
-            properties: {
-              _id: { type: 'string' },
-              bookingId: { type: 'string' },
-              hostId: { type: 'string' },
-              customerId: { type: 'string' },
-              lastMessage: {
-                type: 'object',
-                nullable: true,
-                properties: {
-                  _id: { type: 'string' },
-                  chatId: { type: 'string' },
-                  text: { type: 'string' },
-                  createdAt: { type: 'string' },
-                  createdBy: { type: 'string' },
-                },
-              },
-              createdAt: { type: 'string' },
-              updatedAt: { type: 'string' },
-            },
-          },
+        _id: { type: 'string' },
+        bookingId: { type: 'string' },
+        hostId: { type: 'string' },
+        customerId: { type: 'string' },
+        lastMessage: {
+          type: 'object',
+          nullable: true,
+          properties: MESSAGE_PROPS,
         },
+        createdAt: { type: 'string' },
+        updatedAt: { type: 'string' },
       },
+    }),
+  },
+};
+
+/** @type {import('fastify').RouteOptions['schema']} */
+const listChatMessagesSchema = {
+  description: 'List the messages of the chat room.',
+  tags: ['Messages'],
+  security: [{ Bearer: [] }],
+  querystring: {
+    type: 'object',
+    properties: {
+      page: PAGE_PARAM_PROPS,
     },
+    required: ['page'],
+  },
+  params: {
+    type: 'object',
+    properties: {
+      chatId: { type: 'string' },
+    },
+    required: ['chatId'],
+  },
+  response: {
+    200: paginatedSchema({
+      type: 'object',
+      properties: MESSAGE_PROPS,
+    }),
   },
 };
 
 module.exports = {
   listChatRoomsSchema,
+  listChatMessagesSchema,
 };

--- a/packages/api-gateway/src/drivers/http/server.js
+++ b/packages/api-gateway/src/drivers/http/server.js
@@ -39,6 +39,7 @@ const swaggerOptions = {
       { name: 'Messages', description: 'Messages endpoints' },
       { name: 'Places', description: 'Places endpoints' },
       { name: 'Administration panel', description: 'Administration panel endpoints' },
+      { name: 'Auth', description: 'Auth endpoints' },
     ],
     components: {
       securitySchemes: {

--- a/packages/messages/__tests__/src/use-cases/list-chat-messages.test.js
+++ b/packages/messages/__tests__/src/use-cases/list-chat-messages.test.js
@@ -1,0 +1,138 @@
+// External dependecies
+const { faker } = require('@faker-js/faker');
+
+// Internal dependencies
+const { makeListChatMessages } = require('../../../src/use-cases');
+const { makeMockModel } = require('../../setupTest');
+
+// Mocks
+const mockChatId = faker.datatype.uuid();
+
+const mockMessages = [
+  {
+    _id: faker.datatype.uuid(),
+    chatId: mockChatId,
+    text: faker.lorem.sentence(),
+    createdAt: faker.datatype.datetime(),
+    deletedAt: null,
+    createdBy: faker.datatype.uuid(),
+  },
+];
+
+const MessageModel = makeMockModel(mockMessages);
+
+describe('use-case: listChatMessages', () => {
+  describe('given an invalid message model', () => {
+    describe('when injecting the message model', () => {
+      test('then should return an error', () => {
+        expect(() => makeListChatMessages(null)).toThrow();
+      });
+    });
+  });
+
+  describe('given a valid message model', () => {
+    describe('when injecting the message model', () => {
+      test('then should return a function', () => {
+        const service = makeListChatMessages(MessageModel);
+        expect(typeof service).toBe('function');
+      });
+    });
+  });
+
+  describe('given an invalid chat id and an invalid page', () => {
+    let service;
+
+    beforeAll(() => {
+      service = makeListChatMessages(MessageModel);
+    });
+
+    describe('when requesting the list of messages with undefined as chat id and 1 as page', () => {
+      test('then should return an error', () => {
+        expect(() => service({ chatId: undefined, page: 1 })).rejects.toThrow();
+      });
+    });
+
+    describe('when requesting the list of messages with 1 as chat id and undefined as page', () => {
+      test('then should return an error', () => {
+        expect(() => service({ chatId: 1, page: undefined })).rejects.toThrow();
+      });
+    });
+  });
+
+  describe('given a valid chat id and a valid page', () => {
+    let service;
+
+    beforeAll(() => {
+      service = makeListChatMessages(MessageModel);
+    });
+
+    describe('when requesting the list of messages successfully', () => {
+      let result;
+
+      beforeAll(async () => {
+        result = await service({
+          chatId: mockChatId,
+          page: 1,
+        });
+      });
+
+      test('then result should be an object with the number of pages and the list of messages', () => {
+        expect(result).toHaveProperty('pages');
+        expect(result).toHaveProperty('messages');
+      });
+
+      test('then pages property should be an positive integer', () => {
+        expect(Number.isInteger(result.pages)).toBe(true);
+        expect(result.pages).toBeGreaterThanOrEqual(0);
+      });
+
+      test('then messages property should be an array', () => {
+        expect(Array.isArray(result.messages)).toBe(true);
+      });
+
+      test('and message items should match message schema', () => {
+        const message = result.messages[0];
+
+        expect(message).toBeDefined();
+        expect(message._id).toBeDefined();
+        expect(message.chatId).toBeDefined();
+        expect(message.text).toBeDefined();
+        expect(message.createdAt).toBeDefined();
+        expect(message.deletedAt).toBe(null);
+        expect(message.createdBy).toBeDefined();
+      });
+    });
+
+    describe('when requesting the list of messages with no database connection', () => {
+      let result;
+
+      beforeAll(async () => {
+        MessageModel.find.mockImplementationOnce(() => {
+          throw new Error('Database connection error');
+        });
+
+        result = await service({
+          chatId: mockChatId,
+          page: 1,
+        });
+      });
+
+      test('then result should be an object with the number of pages and the list of messages', () => {
+        expect(result).toHaveProperty('pages');
+        expect(result).toHaveProperty('messages');
+      });
+
+      test('then pages property should be 0', () => {
+        expect(result.pages).toBe(0);
+      });
+
+      test('and messages property should be an empty array', () => {
+        expect(Array.isArray(result.messages)).toBe(true);
+        expect(result.messages.length).toBe(0);
+      });
+
+      test('then result should be an empty array', () => {
+      });
+    });
+  });
+});

--- a/packages/messages/src/index.js
+++ b/packages/messages/src/index.js
@@ -1,10 +1,15 @@
 // Internal dependencies
 const welcome = require('./utils/welcomPackage');
-const { makeListUserChatsService, makeGetChatRoomLastMessage } = require('./use-cases');
+const {
+  makeListUserChatsService,
+  makeGetChatRoomLastMessage,
+  makeListChatMessages,
+} = require('./use-cases');
 const { FakeChatModel, FakeMessageModel } = require('./utils/fixtures');
 
 module.exports = {
   messagesWelcome: welcome,
   listUserChats: makeListUserChatsService(FakeChatModel),
   getChatRoomLastMessage: makeGetChatRoomLastMessage(FakeMessageModel),
+  listChatMessages: makeListChatMessages(FakeMessageModel),
 };

--- a/packages/messages/src/use-cases/index.js
+++ b/packages/messages/src/use-cases/index.js
@@ -1,8 +1,10 @@
 // Internal dependencies
 const makeListUserChatsService = require('./list-user-chats');
 const makeGetChatRoomLastMessage = require('./get-last-message-of-chat-room');
+const makeListChatMessages = require('./list-chat-messages');
 
 module.exports = {
   makeListUserChatsService,
   makeGetChatRoomLastMessage,
+  makeListChatMessages,
 };

--- a/packages/messages/src/use-cases/list-chat-messages.js
+++ b/packages/messages/src/use-cases/list-chat-messages.js
@@ -1,0 +1,91 @@
+// Internal dependencies
+const logger = require('../utils/logger');
+
+/**
+ * Returns the list of messages of a chat room.
+ * List of messages is sorted by creation date and limited to the last 100 messages.
+ *
+ * It will throw an error if the message model dependency has not been injected.
+ *
+ * @param {import('mongoose').Model} MessageModel Message model
+ * @returns {(props: { chatId: string, page: number }) => Promise<{
+ *    pages: number,
+ *    messages: unknown[]
+ * }>}
+ */
+const listChatMessages = (MessageModel) => {
+  if (!MessageModel) {
+    logger.error('[messages]: Message Model dependency has not been injected.');
+    throw new Error('Message Model is required');
+  }
+
+  return async ({ chatId, page }) => {
+    // Validate chat id
+    if (typeof chatId !== 'string' || !chatId) {
+      logger.error('[messages]: Chat Room ID has not been provided.');
+      throw new Error('Chat room ID is required');
+    }
+
+    // Validate page
+    if (!Number.isInteger(page) || page < 1) {
+      const errorMessage = 'Page must be a positive integer greater than 0';
+
+      logger.error(`[messages]: ${errorMessage}`);
+      throw new Error(errorMessage);
+    }
+    // Query
+
+    /** @type {{[key: string]: 0 | 1}} */
+    const fields = {
+      _id: 1,
+      chatId: 1,
+      text: 1,
+      createdAt: 1,
+      deletedAt: 0,
+      createdBy: 1,
+    };
+
+    /** @type {import('mongoose').FilterQuery<unknown>} */
+    const filterOptions = {
+      chatId,
+      deletedAt: null,
+    };
+
+    /** @type {import('mongoose').QueryOptions} */
+    const queryOptions = {
+      sort: { createdAt: -1 },
+      rawResult: true,
+      skip: (page - 1) * 10,
+      limit: 10,
+    };
+
+    let pages = 0;
+    let messages = [];
+    logger.info(`[messages]: Getting messages of chat room #${chatId}`);
+    try {
+      // find with pagination
+      const [count, response] = await Promise.all([
+        MessageModel.countDocuments(filterOptions),
+        MessageModel.find(
+          filterOptions,
+          fields,
+          queryOptions,
+        ),
+      ]);
+
+      if (response) {
+        pages = Math.ceil(count / 10);
+        messages = response;
+      }
+    } catch (error) {
+      logger.error(`[messages]: Error fetching messages of chat room #${chatId}`, error);
+    }
+
+    return {
+      pages,
+      messages,
+    };
+  };
+};
+
+module.exports = listChatMessages;


### PR DESCRIPTION
# Description
This PR adds a new use case and a new endpoint to list the messages of a user chat room.

# Acceptance criteria from #9 
- [x]  The response should be paginated to 10 elements.
- [ ]  The endpoint should validate that the requesting user is related to that chat room.
- [ ]  The endpoint should be protected by a bearer token.
- [x]  The endpoint should only accept application/json as Content-Type.

# Changes
- Solves #9 
- Creates a new use case in the messages package.
- Adds a new endpoint in the api-gateway package.
- Fixes some issues in the api-gateway

# Unsolved tasks
The following tickets have been created to solve the remaining tasks later:
- https://github.com/Platzi-Master-C9/booking-services/issues/178
- https://github.com/Platzi-Master-C9/booking-services/issues/177

# Preview
![Screen Shot 2022-04-15 at 14 21 14](https://user-images.githubusercontent.com/28733681/163633964-b1d07daf-ad36-4ecd-a617-9043769035d7.png)

